### PR TITLE
fix: the markdown of generations was wrong

### DIFF
--- a/base.js
+++ b/base.js
@@ -152,7 +152,7 @@ export async function evolve(generation) {
 				await Promise.all(files.map(async file => await fs.unlink(file)));
 			}
 			const promptFilename = buildPromptFilename(
-				generation === 0 ? name : `generation-${pad(nextGeneration)}`
+				generation === 0 ? name : `generation-${pad(generation)}`
 			);
 			await fs.writeFile(promptFilename, buildPrompt(base));
 


### PR DESCRIPTION
## Motivation

markdown files are always created for the file that was used to start the generation process

## Issues closed

<!-- List closed issues here -->

closes #6 
